### PR TITLE
Fixes #10, adds tick marks to slider

### DIFF
--- a/src/components/SliderInput.vue
+++ b/src/components/SliderInput.vue
@@ -32,7 +32,9 @@ export default {
   },
   mounted () {
     var self = this
-    self.slider = new Slider('#' + self.id)
+    self.slider = new Slider('#' + self.id, {
+      ticks: [this.min, this.start, this.max]
+    })
     self.slider.on('slide', function (value) {
       self.value = value
       self.$emit('updated', self.id, value)


### PR DESCRIPTION
Right now, the middle tick is added to the "starting" value which may or may not (depending on if the person is using an adjusted link) be the "projected for Financial Framework 2025" value.  Can revise in the future.