### PR TITLE
Add many more sliders, change which fields are shown

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,41 +5,45 @@
       <div class="col-md-6">
         <spreadsheet
           :studentFte2016="studentFte2016"
+          :studentFte2018="studentFte2018"
+          :studentFte2019="studentFte2019"
+          :studentFte2020="studentFte2020"
           :studentFte2025="studentFte2025"
           :studentFte2025start="studentFte2025start"
           :studentFte2025min="studentFte2025min"
           :studentFte2025max="studentFte2025max"
+
           :tuitionFeesFTE2016="tuitionFeesFTE2016"
+
+          :totalStateAppropriation2016="totalStateAppropriation2016"
+
           :tuitionFeesFTE2025="tuitionFeesFTE2025"
           :tuitionFeesFTE2025start="tuitionFeesFTE2025start"
           :tuitionFeesFTE2025min="tuitionFeesFTE2025min"
           :tuitionFeesFTE2025max="tuitionFeesFTE2025max"
-          :stateAppropriationFTE2016="stateAppropriationFTE2016"
-          :stateAppropriationFTE2025="stateAppropriationFTE2025"
-          :stateAppropriationFTE2025start="stateAppropriationFTE2025start"
-          :stateAppropriationFTE2025min="stateAppropriationFTE2025min"
-          :stateAppropriationFTE2025max="stateAppropriationFTE2025max"
-          :totalTuitionFees2016="totalTuitionFees2016"
-          :totalTuitionFees2025="totalTuitionFees2025"
-          :totalTuitionFees2025start="totalTuitionFees2025start"
-          :totalStateAppropriation2016="totalStateAppropriation2016"
+
           :totalStateAppropriation2025="totalStateAppropriation2025"
           :totalStateAppropriation2025start="totalStateAppropriation2025start"
+          :totalStateAppropriation2025min="totalStateAppropriation2025min"
+          :totalStateAppropriation2025max="totalStateAppropriation2025max"
+
+          :totalTuitionFees2016="totalTuitionFees2016"
+          :totalTuitionFees2025="totalTuitionFees2025"
+
           :revenueEducationCost2016="revenueEducationCost2016"
           :revenueEducationCost2025="revenueEducationCost2025"
-          :revenueEducationCost2025start="revenueEducationCost2025start"
           v-on:updated="updated"
         ></spreadsheet>
       </div>
       <div class="col-md-6">
-        <graph
+        <!-- <graph
           :studentFte2016="studentFte2016"
           :studentFte2025="studentFte2025"
           :totalTuitionFees2016="totalTuitionFees2016"
           :totalTuitionFees2025="totalTuitionFees2025"
           :totalStateAppropriation2016="totalStateAppropriation2016"
           :totalStateAppropriation2025="totalStateAppropriation2025"
-        ></graph>
+        ></graph> -->
       </div>
     </div>
   </div>
@@ -62,64 +66,48 @@ export default {
     this.restoreValuesFromUrl([
       'studentFte2025',
       'tuitionFeesFTE2025',
-      'stateAppropriationFTE2025'
+      'totalStateAppropriation2025'
     ])
   },
   data: () => ({
+    /* Student FTEs (enrollment) */
     studentFte2016: 19229,
+    // Linear interpolation for FY2017-2020 to this last value
     studentFte2025start: 26805,
     studentFte2025min: 10000,
     studentFte2025max: 35000,
+
     tuitionFeesFTE2016: 6806,
     tuitionFeesFTE2025start: 10089,
     tuitionFeesFTE2025min: 5000,
     tuitionFeesFTE2025max: 15000,
-    stateAppropriationFTE2016: 16692,
-    stateAppropriationFTE2025start: 11642,
-    stateAppropriationFTE2025min: 8000,
-    stateAppropriationFTE2025max: 20000
+
+    totalStateAppropriation2016: 350,
+    totalStateAppropriation2025start: 344,
+    totalStateAppropriation2025min: 200,
+    totalStateAppropriation2025max: 500,
+
+    totalTuitionFees2016: 130.9,
+
+    revenueEducationCost2016: 480.9
   }),
   computed: {
-    studentFte2025 () {
-      return this.$store.state.studentFte2025
-    },
-    tuitionFeesFTE2025 () {
-      return this.$store.state.tuitionFeesFTE2025
-    },
-    stateAppropriationFTE2025 () {
-      return this.$store.state.stateAppropriationFTE2025
-    },
-    totalTuitionFees2016: function () {
-      return ((this.tuitionFeesFTE2016 * this.studentFte2016) / 1000000).toFixed(2)
-    },
+    studentFte2018 () { return this.interpolateStudentFte(2018) },
+    studentFte2019 () { return this.interpolateStudentFte(2019) },
+    studentFte2020 () { return this.interpolateStudentFte(2020) },
+    studentFte2025 () { return this.$store.state.studentFte2025 },
+    tuitionFeesFTE2025 () { return this.$store.state.tuitionFeesFTE2025 },
+    totalStateAppropriation2025 () { return this.$store.state.totalStateAppropriation2025 },
+
     totalTuitionFees2025: function () {
       return ((this.tuitionFeesFTE2025 * this.studentFte2025) / 1000000).toFixed(2)
     },
-    totalTuitionFees2025start: function () {
-      return ((this.tuitionFeesFTE2025start * this.studentFte2025start) / 1000000).toFixed(2)
-    },
-    totalStateAppropriation2016: function () {
-      return ((this.stateAppropriationFTE2016 * this.studentFte2016) / 1000000).toFixed(2)
-    },
-    totalStateAppropriation2025: function () {
-      return ((this.stateAppropriationFTE2025 * this.studentFte2025) / 1000000).toFixed(2)
-    },
-    totalStateAppropriation2025start: function () {
-      return ((this.stateAppropriationFTE2025start * this.studentFte2025start) / 1000000).toFixed(2)
-    },
-    revenueEducationCost2016: function () {
-      return (((this.tuitionFeesFTE2016 + this.stateAppropriationFTE2016) * this.studentFte2016) / 1000000).toFixed(2)
-    },
     revenueEducationCost2025: function () {
-      return (((this.tuitionFeesFTE2025 + this.stateAppropriationFTE2025) * this.studentFte2025) / 1000000).toFixed(2)
-    },
-    revenueEducationCost2025start: function () {
-      return (((this.tuitionFeesFTE2025start + this.stateAppropriationFTE2025start) * this.studentFte2025start) / 1000000).toFixed(2)
+      return parseFloat(this.totalTuitionFees2025) + parseFloat(this.totalStateAppropriation2025)
     }
   },
   methods: {
     restoreValuesFromUrl (items) {
-      console.log(items)
       _.each(items, (item) => {
         if (this.$route.params[item]) {
           this.setStoreValue(item, this.validate(item, this.$route.params[item]))
@@ -132,11 +120,15 @@ export default {
         value: value
       })
     },
+    // Returns a linear interpolation of student population
+    interpolateStudentFte (year) {
+      var m = (this.studentFte2025 - this.studentFte2016) / 9
+      return Math.floor(m * (year - 2016) + 19229)
+    },
     // Basic validation to check type safety,
     // can add min/max if needed later.  Sets to 0 if invalid.
     validate (item, value) {
       var validated = parseInt(value)
-      console.log(validated)
       if (_.isNaN(validated) === true) {
         validated = 0
       }
@@ -159,13 +151,13 @@ export default {
           } else {
             return this.tuitionFeesFTE2025max
           }
-        case 'stateAppropriationFTE2025':
-          if (validated >= this.stateAppropriationFTE2025min && validated <= this.stateAppropriationFTE2025max) {
+        case 'totalStateAppropriation2025':
+          if (validated >= this.totalStateAppropriation2025min && validated <= this.totalStateAppropriation2025max) {
             return validated
-          } else if (validated < this.stateAppropriationFTE2025min) {
-            return this.stateAppropriationFTE2025min
+          } else if (validated < this.totalStateAppropriation2025min) {
+            return this.totalStateAppropriation2025min
           } else {
-            return this.stateAppropriationFTE2025max
+            return this.totalStateAppropriation2025max
           }
         default:
           break
@@ -179,7 +171,7 @@ export default {
         params: {
           studentFte2025: this.studentFte2025,
           tuitionFeesFTE2025: this.tuitionFeesFTE2025,
-          stateAppropriationFTE2025: this.stateAppropriationFTE2025
+          totalStateAppropriation2025: this.totalStateAppropriation2025
         }
       })
     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container">
+  <div class="container-fluid">
     <h1>UA Financial Framework Visualization Tool</h1>
     <div class="row">
       <div class="col-md-6">
@@ -71,14 +71,25 @@
         ></spreadsheet>
       </div>
       <div class="col-md-6">
-        <!-- <graph
+        <graph
           :studentFte2016="studentFte2016"
+          :studentFte2018="studentFte2018"
+          :studentFte2019="studentFte2019"
+          :studentFte2020="studentFte2020"
           :studentFte2025="studentFte2025"
-          :totalTuitionFees2016="totalTuitionFees2016"
-          :totalTuitionFees2025="totalTuitionFees2025"
+
           :totalStateAppropriation2016="totalStateAppropriation2016"
+          :totalStateAppropriation2018="totalStateAppropriation2018"
+          :totalStateAppropriation2019="totalStateAppropriation2019"
+          :totalStateAppropriation2020="totalStateAppropriation2020"
           :totalStateAppropriation2025="totalStateAppropriation2025"
-        ></graph> -->
+
+          :totalTuitionFees2016="totalTuitionFees2016"
+          :totalTuitionFees2018="totalTuitionFees2018"
+          :totalTuitionFees2019="totalTuitionFees2019"
+          :totalTuitionFees2020="totalTuitionFees2020"
+          :totalTuitionFees2025="totalTuitionFees2025"
+        ></graph>
       </div>
     </div>
   </div>
@@ -184,13 +195,13 @@ export default {
   },
   methods: {
     computeStateAppropriationPerFTE (fte, appropriation) {
-      return (parseFloat(appropriation) * 1000000 / parseFloat(fte)).toFixed(2)
+      return parseFloat((parseFloat(appropriation) * 1000000 / parseFloat(fte)).toFixed(2))
     },
     computeRevenueEducationCost (tuition, appropriation) {
-      return (parseFloat(tuition) + parseFloat(appropriation)).toFixed(2)
+      return parseFloat((parseFloat(tuition) + parseFloat(appropriation)).toFixed(2))
     },
     computeTotalTuitionFees (fees, fte) {
-      return ((fees * fte) / 1000000).toFixed(2)
+      return parseFloat(((fees * fte) / 1000000).toFixed(2))
     },
     restoreValuesFromUrl (items) {
       _.each(items, (item) => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,23 +14,52 @@
           :studentFte2025max="studentFte2025max"
 
           :tuitionFeesFTE2016="tuitionFeesFTE2016"
-
-          :totalStateAppropriation2016="totalStateAppropriation2016"
+          :tuitionFeesFTE2018="tuitionFeesFTE2018"
+          :tuitionFeesFTE2018start="tuitionFeesFTE2018start"
+          :tuitionFeesFTE2018min="tuitionFeesFTE2018min"
+          :tuitionFeesFTE2018max="tuitionFeesFTE2018max"
+          :tuitionFeesFTE2019="tuitionFeesFTE2019"
+          :tuitionFeesFTE2019start="tuitionFeesFTE2019start"
+          :tuitionFeesFTE2019min="tuitionFeesFTE2019min"
+          :tuitionFeesFTE2019max="tuitionFeesFTE2019max"
+          :tuitionFeesFTE2020="tuitionFeesFTE2020"
+          :tuitionFeesFTE2020start="tuitionFeesFTE2020start"
+          :tuitionFeesFTE2020min="tuitionFeesFTE2020min"
+          :tuitionFeesFTE2020max="tuitionFeesFTE2020max"
 
           :tuitionFeesFTE2025="tuitionFeesFTE2025"
           :tuitionFeesFTE2025start="tuitionFeesFTE2025start"
           :tuitionFeesFTE2025min="tuitionFeesFTE2025min"
           :tuitionFeesFTE2025max="tuitionFeesFTE2025max"
 
+          :totalStateAppropriation2016="totalStateAppropriation2016"
+          :totalStateAppropriation2018="totalStateAppropriation2018"
+          :totalStateAppropriation2018start="totalStateAppropriation2018start"
+          :totalStateAppropriation2018min="totalStateAppropriation2018min"
+          :totalStateAppropriation2018max="totalStateAppropriation2018max"
+          :totalStateAppropriation2019="totalStateAppropriation2019"
+          :totalStateAppropriation2019start="totalStateAppropriation2019start"
+          :totalStateAppropriation2019min="totalStateAppropriation2019min"
+          :totalStateAppropriation2019max="totalStateAppropriation2019max"
+          :totalStateAppropriation2020="totalStateAppropriation2020"
+          :totalStateAppropriation2020start="totalStateAppropriation2020start"
+          :totalStateAppropriation2020min="totalStateAppropriation2020min"
+          :totalStateAppropriation2020max="totalStateAppropriation2020max"
           :totalStateAppropriation2025="totalStateAppropriation2025"
           :totalStateAppropriation2025start="totalStateAppropriation2025start"
           :totalStateAppropriation2025min="totalStateAppropriation2025min"
           :totalStateAppropriation2025max="totalStateAppropriation2025max"
 
           :totalTuitionFees2016="totalTuitionFees2016"
+          :totalTuitionFees2018="totalTuitionFees2018"
+          :totalTuitionFees2019="totalTuitionFees2019"
+          :totalTuitionFees2020="totalTuitionFees2020"
           :totalTuitionFees2025="totalTuitionFees2025"
 
           :revenueEducationCost2016="revenueEducationCost2016"
+          :revenueEducationCost2018="revenueEducationCost2018"
+          :revenueEducationCost2019="revenueEducationCost2019"
+          :revenueEducationCost2020="revenueEducationCost2020"
           :revenueEducationCost2025="revenueEducationCost2025"
           v-on:updated="updated"
         ></spreadsheet>
@@ -65,7 +94,13 @@ export default {
   created () {
     this.restoreValuesFromUrl([
       'studentFte2025',
+      'tuitionFeesFTE2018',
+      'tuitionFeesFTE2019',
+      'tuitionFeesFTE2020',
       'tuitionFeesFTE2025',
+      'totalStateAppropriation2018',
+      'totalStateAppropriation2019',
+      'totalStateAppropriation2020',
       'totalStateAppropriation2025'
     ])
   },
@@ -78,14 +113,32 @@ export default {
     studentFte2025max: 35000,
 
     tuitionFeesFTE2016: 6806,
+    tuitionFeesFTE2018start: 7000,
+    tuitionFeesFTE2018min: 5000,
+    tuitionFeesFTE2018max: 15000,
+    tuitionFeesFTE2019start: 7500,
+    tuitionFeesFTE2019min: 5000,
+    tuitionFeesFTE2019max: 15000,
+    tuitionFeesFTE2020start: 8000,
+    tuitionFeesFTE2020min: 5000,
+    tuitionFeesFTE2020max: 15000,
     tuitionFeesFTE2025start: 10089,
     tuitionFeesFTE2025min: 5000,
     tuitionFeesFTE2025max: 15000,
 
     totalStateAppropriation2016: 350,
-    totalStateAppropriation2025start: 344,
+    totalStateAppropriation2018min: 200,
+    totalStateAppropriation2018max: 500,
+    totalStateAppropriation2018start: 340,
+    totalStateAppropriation2019min: 200,
+    totalStateAppropriation2019max: 500,
+    totalStateAppropriation2019start: 330,
+    totalStateAppropriation2020min: 200,
+    totalStateAppropriation2020max: 500,
+    totalStateAppropriation2020start: 323,
     totalStateAppropriation2025min: 200,
     totalStateAppropriation2025max: 500,
+    totalStateAppropriation2025start: 318,
 
     totalTuitionFees2016: 130.9,
 
@@ -96,17 +149,34 @@ export default {
     studentFte2019 () { return this.interpolateStudentFte(2019) },
     studentFte2020 () { return this.interpolateStudentFte(2020) },
     studentFte2025 () { return this.$store.state.studentFte2025 },
+
+    tuitionFeesFTE2018 () { return this.$store.state.tuitionFeesFTE2018 },
+    tuitionFeesFTE2019 () { return this.$store.state.tuitionFeesFTE2019 },
+    tuitionFeesFTE2020 () { return this.$store.state.tuitionFeesFTE2020 },
     tuitionFeesFTE2025 () { return this.$store.state.tuitionFeesFTE2025 },
+
+    totalStateAppropriation2018 () { return this.$store.state.totalStateAppropriation2018 },
+    totalStateAppropriation2019 () { return this.$store.state.totalStateAppropriation2019 },
+    totalStateAppropriation2020 () { return this.$store.state.totalStateAppropriation2020 },
     totalStateAppropriation2025 () { return this.$store.state.totalStateAppropriation2025 },
 
-    totalTuitionFees2025: function () {
-      return ((this.tuitionFeesFTE2025 * this.studentFte2025) / 1000000).toFixed(2)
-    },
-    revenueEducationCost2025: function () {
-      return parseFloat(this.totalTuitionFees2025) + parseFloat(this.totalStateAppropriation2025)
-    }
+    totalTuitionFees2018: function () { return this.computeTotalTuitionFees(this.tuitionFeesFTE2018, this.studentFte2018) },
+    totalTuitionFees2019: function () { return this.computeTotalTuitionFees(this.tuitionFeesFTE2019, this.studentFte2019) },
+    totalTuitionFees2020: function () { return this.computeTotalTuitionFees(this.tuitionFeesFTE2020, this.studentFte2020) },
+    totalTuitionFees2025: function () { return this.computeTotalTuitionFees(this.tuitionFeesFTE2025, this.studentFte2025) },
+
+    revenueEducationCost2018: function () { return this.computeRevenueEducationCost(this.totalTuitionFees2025, this.totalStateAppropriation2018) },
+    revenueEducationCost2019: function () { return this.computeRevenueEducationCost(this.totalTuitionFees2025, this.totalStateAppropriation2019) },
+    revenueEducationCost2020: function () { return this.computeRevenueEducationCost(this.totalTuitionFees2025, this.totalStateAppropriation2020) },
+    revenueEducationCost2025: function () { return this.computeRevenueEducationCost(this.totalTuitionFees2025, this.totalStateAppropriation2025) }
   },
   methods: {
+    computeRevenueEducationCost (tuition, appropriation) {
+      return (parseFloat(tuition) + parseFloat(appropriation)).toFixed(2)
+    },
+    computeTotalTuitionFees (fees, fte) {
+      return ((fees * fte) / 1000000).toFixed(2)
+    },
     restoreValuesFromUrl (items) {
       _.each(items, (item) => {
         if (this.$route.params[item]) {
@@ -170,7 +240,13 @@ export default {
         name: 'edited',
         params: {
           studentFte2025: this.studentFte2025,
+          tuitionFeesFTE2018: this.tuitionFeesFTE2018,
+          tuitionFeesFTE2019: this.tuitionFeesFTE2019,
+          tuitionFeesFTE2020: this.tuitionFeesFTE2020,
           tuitionFeesFTE2025: this.tuitionFeesFTE2025,
+          totalStateAppropriation2018: this.totalStateAppropriation2018,
+          totalStateAppropriation2019: this.totalStateAppropriation2019,
+          totalStateAppropriation2020: this.totalStateAppropriation2020,
           totalStateAppropriation2025: this.totalStateAppropriation2025
         }
       })

--- a/src/App.vue
+++ b/src/App.vue
@@ -50,6 +50,12 @@
           :totalStateAppropriation2025min="totalStateAppropriation2025min"
           :totalStateAppropriation2025max="totalStateAppropriation2025max"
 
+          :stateAppropriationPerFTE2016="stateAppropriationPerFTE2016"
+          :stateAppropriationPerFTE2018="stateAppropriationPerFTE2018"
+          :stateAppropriationPerFTE2019="stateAppropriationPerFTE2019"
+          :stateAppropriationPerFTE2020="stateAppropriationPerFTE2020"
+          :stateAppropriationPerFTE2025="stateAppropriationPerFTE2025"
+
           :totalTuitionFees2016="totalTuitionFees2016"
           :totalTuitionFees2018="totalTuitionFees2018"
           :totalTuitionFees2019="totalTuitionFees2019"
@@ -160,6 +166,12 @@ export default {
     totalStateAppropriation2020 () { return this.$store.state.totalStateAppropriation2020 },
     totalStateAppropriation2025 () { return this.$store.state.totalStateAppropriation2025 },
 
+    stateAppropriationPerFTE2016 () { return this.computeStateAppropriationPerFTE(this.studentFte2016, this.totalStateAppropriation2016) },
+    stateAppropriationPerFTE2018 () { return this.computeStateAppropriationPerFTE(this.studentFte2018, this.totalStateAppropriation2018) },
+    stateAppropriationPerFTE2019 () { return this.computeStateAppropriationPerFTE(this.studentFte2019, this.totalStateAppropriation2019) },
+    stateAppropriationPerFTE2020 () { return this.computeStateAppropriationPerFTE(this.studentFte2020, this.totalStateAppropriation2020) },
+    stateAppropriationPerFTE2025 () { return this.computeStateAppropriationPerFTE(this.studentFte2025, this.totalStateAppropriation2025) },
+
     totalTuitionFees2018: function () { return this.computeTotalTuitionFees(this.tuitionFeesFTE2018, this.studentFte2018) },
     totalTuitionFees2019: function () { return this.computeTotalTuitionFees(this.tuitionFeesFTE2019, this.studentFte2019) },
     totalTuitionFees2020: function () { return this.computeTotalTuitionFees(this.tuitionFeesFTE2020, this.studentFte2020) },
@@ -171,6 +183,9 @@ export default {
     revenueEducationCost2025: function () { return this.computeRevenueEducationCost(this.totalTuitionFees2025, this.totalStateAppropriation2025) }
   },
   methods: {
+    computeStateAppropriationPerFTE (fte, appropriation) {
+      return (parseFloat(appropriation) * 1000000 / parseFloat(fte)).toFixed(2)
+    },
     computeRevenueEducationCost (tuition, appropriation) {
       return (parseFloat(tuition) + parseFloat(appropriation)).toFixed(2)
     },

--- a/src/components/SliderInput.vue
+++ b/src/components/SliderInput.vue
@@ -3,7 +3,7 @@
     <div class="form-group" v-bind:class="{ 'form-group--error': $v.value.$error } ">
       <input
         ref="input"
-        class="form__input"
+        class="form__input input"
         v-model:trim="value"
         v-model:value="value"
         v-on:input="updateValue($event.target.value, $v.value.between)"
@@ -74,3 +74,12 @@ export default {
   }
 }
 </script>
+
+<style>
+input.input {
+  max-width: 6em;
+}
+.slider.slider-horizontal {
+  max-width: 100px;
+}
+</style>

--- a/src/components/Spreadsheet.vue
+++ b/src/components/Spreadsheet.vue
@@ -5,14 +5,19 @@
         <tr>
           <th scope="col"></th>
           <th scope="col">2016</th>
-          <th scope="col">2025</th>
+          <th scope="col">FY2018</th>
+          <th scope="col">FY2019</th>
+          <th scope="col">FY2020</th>
+          <th scope="col">FY2025</th>
         </tr>
       </thead>
       <tbody>
         <tr>
           <th scope="row">Current Student Full-Time Equivalents (FTE)</th>
-          <td>{{ studentFte2016 }}
-          </td>
+          <td>{{ studentFte2016 }}</td>
+          <td>{{ studentFte2018 }}</td>
+          <td>{{ studentFte2019 }}</td>
+          <td>{{ studentFte2020 }}</td>
           <td>
             <slider-input
               id="studentFte2025"
@@ -30,6 +35,15 @@
             {{ tuitionFeesFTE2016 }}
           </td>
           <td>
+            placeholder
+          </td>
+          <td>
+            placeholder
+          </td>
+          <td>
+            placeholder
+          </td>
+          <td>
             <slider-input
               id="tuitionFeesFTE2025"
               :min="tuitionFeesFTE2025min"
@@ -41,17 +55,26 @@
           </td>
         </tr>
         <tr>
-          <th scope="row">State Appropriation per Student FTE</th>
+          <th scope="row">Total State Appropriation</th>
           <td>
-            {{ stateAppropriationFTE2016 }}
+            {{ totalStateAppropriation2016 }}
+          </td>
+          <td>
+            placeholder
+          </td>
+          <td>
+            placeholder
+          </td>
+          <td>
+            placeholder
           </td>
           <td>
             <slider-input
-              id="stateAppropriationFTE2025"
-              :min="stateAppropriationFTE2025min"
-              :max="stateAppropriationFTE2025max"
-              :start="stateAppropriationFTE2025start"
-              :currvalue="stateAppropriationFTE2025"
+              id="totalStateAppropriation2025"
+              :min="totalStateAppropriation2025min"
+              :max="totalStateAppropriation2025max"
+              :start="totalStateAppropriation2025start"
+              :currvalue="totalStateAppropriation2025"
               v-on:updated="updated"
             ></slider-input>
           </td>
@@ -60,21 +83,18 @@
           <th scope="row">Total Tuition &amp; Fees (Million $)</th>
           <td>{{ totalTuitionFees2016 }}</td>
           <td>
+            placeholder
+          </td>
+          <td>
+            placeholder
+          </td>
+          <td>
+            placeholder
+          </td>
+          <td>
             {{ totalTuitionFees2025 }}
             <percent-change
               :value="totalTuitionFees2025"
-              :start="totalTuitionFees2025start"
-            ></percent-change>
-          </td>
-        </tr>
-        <tr>
-          <th scope="row">Total State Appropriation (Million $)</th>
-          <td>{{ totalStateAppropriation2016 }}</td>
-          <td>
-            {{ totalStateAppropriation2025 }}
-            <percent-change
-              :value="totalStateAppropriation2025"
-              :start="totalStateAppropriation2025start"
             ></percent-change>
           </td>
         </tr>
@@ -82,10 +102,18 @@
           <th scope="row">Revenue, Educational Cost (Million $)</th>
           <td>{{ revenueEducationCost2016 }}</td>
           <td>
+            placeholder
+          </td>
+          <td>
+            placeholder
+          </td>
+          <td>
+            placeholder
+          </td>
+          <td>
             {{ revenueEducationCost2025 }}
             <percent-change
               :value="revenueEducationCost2025"
-              :start="revenueEducationCost2025start"
             ></percent-change>
           </td>
         </tr>
@@ -106,29 +134,30 @@ export default {
   },
   props: [
     'studentFte2016',
+    'studentFte2018',
+    'studentFte2019',
+    'studentFte2020',
     'studentFte2025',
     'studentFte2025start',
     'studentFte2025min',
     'studentFte2025max',
+
     'tuitionFeesFTE2016',
     'tuitionFeesFTE2025',
     'tuitionFeesFTE2025start',
     'tuitionFeesFTE2025min',
     'tuitionFeesFTE2025max',
-    'stateAppropriationFTE2016',
-    'stateAppropriationFTE2025',
-    'stateAppropriationFTE2025start',
-    'stateAppropriationFTE2025min',
-    'stateAppropriationFTE2025max',
     'totalTuitionFees2016',
     'totalTuitionFees2025',
-    'totalTuitionFees2025start',
-    'revenueEducationCost2016',
-    'revenueEducationCost2025',
-    'revenueEducationCost2025start',
+
     'totalStateAppropriation2016',
     'totalStateAppropriation2025',
-    'totalStateAppropriation2025start'
+    'totalStateAppropriation2025min',
+    'totalStateAppropriation2025max',
+    'totalStateAppropriation2025start',
+
+    'revenueEducationCost2016',
+    'revenueEducationCost2025'
   ],
   methods: {
     updated: function (item, value) {

--- a/src/components/Spreadsheet.vue
+++ b/src/components/Spreadsheet.vue
@@ -35,13 +35,34 @@
             {{ tuitionFeesFTE2016 }}
           </td>
           <td>
-            placeholder
+            <slider-input
+              id="tuitionFeesFTE2018"
+              :min="tuitionFeesFTE2018min"
+              :max="tuitionFeesFTE2018max"
+              :start="tuitionFeesFTE2018start"
+              :currvalue="tuitionFeesFTE2018"
+              v-on:updated="updated"
+            ></slider-input>
           </td>
           <td>
-            placeholder
+            <slider-input
+              id="tuitionFeesFTE2019"
+              :min="tuitionFeesFTE2019min"
+              :max="tuitionFeesFTE2019max"
+              :start="tuitionFeesFTE2019start"
+              :currvalue="tuitionFeesFTE2019"
+              v-on:updated="updated"
+            ></slider-input>
           </td>
           <td>
-            placeholder
+            <slider-input
+              id="tuitionFeesFTE2020"
+              :min="tuitionFeesFTE2020min"
+              :max="tuitionFeesFTE2020max"
+              :start="tuitionFeesFTE2020start"
+              :currvalue="tuitionFeesFTE2020"
+              v-on:updated="updated"
+            ></slider-input>
           </td>
           <td>
             <slider-input
@@ -55,18 +76,39 @@
           </td>
         </tr>
         <tr>
-          <th scope="row">Total State Appropriation</th>
+          <th scope="row">Total State Appropriation (Million $)</th>
           <td>
             {{ totalStateAppropriation2016 }}
           </td>
           <td>
-            placeholder
+            <slider-input
+              id="totalStateAppropriation2018"
+              :min="totalStateAppropriation2018min"
+              :max="totalStateAppropriation2018max"
+              :start="totalStateAppropriation2018start"
+              :currvalue="totalStateAppropriation2018"
+              v-on:updated="updated"
+            ></slider-input>
           </td>
           <td>
-            placeholder
+            <slider-input
+              id="totalStateAppropriation2019"
+              :min="totalStateAppropriation2019min"
+              :max="totalStateAppropriation2019max"
+              :start="totalStateAppropriation2019start"
+              :currvalue="totalStateAppropriation2019"
+              v-on:updated="updated"
+            ></slider-input>
           </td>
           <td>
-            placeholder
+            <slider-input
+              id="totalStateAppropriation2020"
+              :min="totalStateAppropriation2020min"
+              :max="totalStateAppropriation2020max"
+              :start="totalStateAppropriation2020start"
+              :currvalue="totalStateAppropriation2020"
+              v-on:updated="updated"
+            ></slider-input>
           </td>
           <td>
             <slider-input
@@ -83,13 +125,13 @@
           <th scope="row">Total Tuition &amp; Fees (Million $)</th>
           <td>{{ totalTuitionFees2016 }}</td>
           <td>
-            placeholder
+            {{ totalTuitionFees2018 }}
           </td>
           <td>
-            placeholder
+            {{ totalTuitionFees2019 }}
           </td>
           <td>
-            placeholder
+            {{ totalTuitionFees2020 }}
           </td>
           <td>
             {{ totalTuitionFees2025 }}
@@ -102,13 +144,13 @@
           <th scope="row">Revenue, Educational Cost (Million $)</th>
           <td>{{ revenueEducationCost2016 }}</td>
           <td>
-            placeholder
+            {{ revenueEducationCost2018 }}
           </td>
           <td>
-            placeholder
+            {{ revenueEducationCost2019 }}
           </td>
           <td>
-            placeholder
+            {{ revenueEducationCost2020 }}
           </td>
           <td>
             {{ revenueEducationCost2025 }}
@@ -143,20 +185,51 @@ export default {
     'studentFte2025max',
 
     'tuitionFeesFTE2016',
+    'tuitionFeesFTE2018',
+    'tuitionFeesFTE2018start',
+    'tuitionFeesFTE2018min',
+    'tuitionFeesFTE2018max',
+    'tuitionFeesFTE2019',
+    'tuitionFeesFTE2019start',
+    'tuitionFeesFTE2019min',
+    'tuitionFeesFTE2019max',
+    'tuitionFeesFTE2020',
+    'tuitionFeesFTE2020start',
+    'tuitionFeesFTE2020min',
+    'tuitionFeesFTE2020max',
     'tuitionFeesFTE2025',
     'tuitionFeesFTE2025start',
     'tuitionFeesFTE2025min',
     'tuitionFeesFTE2025max',
-    'totalTuitionFees2016',
-    'totalTuitionFees2025',
 
     'totalStateAppropriation2016',
+    'totalStateAppropriation2018',
+    'totalStateAppropriation2018start',
+    'totalStateAppropriation2018min',
+    'totalStateAppropriation2018max',
+    'totalStateAppropriation2019',
+    'totalStateAppropriation2019start',
+    'totalStateAppropriation2019min',
+    'totalStateAppropriation2019max',
+    'totalStateAppropriation2020',
+    'totalStateAppropriation2020start',
+    'totalStateAppropriation2020min',
+    'totalStateAppropriation2020max',
     'totalStateAppropriation2025',
+    'totalStateAppropriation2025start',
     'totalStateAppropriation2025min',
     'totalStateAppropriation2025max',
-    'totalStateAppropriation2025start',
+
+    'totalTuitionFees2016',
+    'totalTuitionFees2018',
+    'totalTuitionFees2019',
+    'totalTuitionFees2020',
+    'totalTuitionFees2025',
 
     'revenueEducationCost2016',
+    'revenueEducationCost2018',
+    'revenueEducationCost2019',
+    'revenueEducationCost2020',
     'revenueEducationCost2025'
   ],
   methods: {
@@ -169,4 +242,7 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
+table.table>tbody>tr>td {
+  padding: 1em;
+}
 </style>

--- a/src/components/Spreadsheet.vue
+++ b/src/components/Spreadsheet.vue
@@ -122,6 +122,25 @@
           </td>
         </tr>
         <tr>
+          <th scope="row">State Appropriation per FTE</th>
+          <td>{{ stateAppropriationPerFTE2016 }}</td>
+          <td>
+            {{ stateAppropriationPerFTE2018 }}
+          </td>
+          <td>
+            {{ stateAppropriationPerFTE2019 }}
+          </td>
+          <td>
+            {{ stateAppropriationPerFTE2020 }}
+          </td>
+          <td>
+            {{ stateAppropriationPerFTE2025 }}
+            <percent-change
+              :value="stateAppropriationPerFTE2025"
+            ></percent-change>
+          </td>
+        </tr>
+        <tr>
           <th scope="row">Total Tuition &amp; Fees (Million $)</th>
           <td>{{ totalTuitionFees2016 }}</td>
           <td>
@@ -219,6 +238,12 @@ export default {
     'totalStateAppropriation2025start',
     'totalStateAppropriation2025min',
     'totalStateAppropriation2025max',
+
+    'stateAppropriationPerFTE2016',
+    'stateAppropriationPerFTE2018',
+    'stateAppropriationPerFTE2019',
+    'stateAppropriationPerFTE2020',
+    'stateAppropriationPerFTE2025',
 
     'totalTuitionFees2016',
     'totalTuitionFees2018',

--- a/src/components/Spreadsheet.vue
+++ b/src/components/Spreadsheet.vue
@@ -268,6 +268,6 @@ export default {
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
 table.table>tbody>tr>td {
-  padding: 1em;
+  padding: 1ex 1em;
 }
 </style>

--- a/src/router.js
+++ b/src/router.js
@@ -6,7 +6,7 @@ Vue.use(VueRouter)
 export default new VueRouter({
   routes: [
     {
-      path: '/:studentFte2025/:tuitionFeesFTE2025/:stateAppropriationFTE2025',
+      path: '/:studentFte2025/:tuitionFeesFTE2025/:totalStateAppropriation2025',
       name: 'edited'
     }
   ]

--- a/src/router.js
+++ b/src/router.js
@@ -6,7 +6,7 @@ Vue.use(VueRouter)
 export default new VueRouter({
   routes: [
     {
-      path: '/:studentFte2025/:tuitionFeesFTE2025/:totalStateAppropriation2025',
+      path: '/:studentFte2025/:tuitionFeesFTE2018/:tuitionFeesFTE2019/:tuitionFeesFTE2020/:tuitionFeesFTE2025/:totalStateAppropriation2018/:totalStateAppropriation2019/:totalStateAppropriation2020/:totalStateAppropriation2025',
       name: 'edited'
     }
   ]

--- a/src/store.js
+++ b/src/store.js
@@ -11,7 +11,13 @@ export default new Vuex.Store({
     // These defaults are from the UA Financial Framework assumptions
     // provided via email/spreadsheet
     studentFte2025: 26805,
+    tuitionFeesFTE2018: 7000,
+    tuitionFeesFTE2019: 7500,
+    tuitionFeesFTE2020: 8000,
     tuitionFeesFTE2025: 10089,
+    totalStateAppropriation2018: 340,
+    totalStateAppropriation2019: 330,
+    totalStateAppropriation2020: 323,
     totalStateAppropriation2025: 312
   },
   mutations: {

--- a/src/store.js
+++ b/src/store.js
@@ -12,7 +12,7 @@ export default new Vuex.Store({
     // provided via email/spreadsheet
     studentFte2025: 26805,
     tuitionFeesFTE2025: 10089,
-    stateAppropriationFTE2025: 11642
+    totalStateAppropriation2025: 312
   },
   mutations: {
     update (state, payload) {


### PR DESCRIPTION
This PR addresses a number of change requests:

 - Sliders added for FY2018, 2019, 2020 for FTE Tuition/Fees and Total State Appropriation
 - State Appropriation per FTE is now computed from Total State Appropriation instead of the other way around
 - Student FTEs is linearly interpolated from 2016 - 2025
 - The Graph is updated to show explicitly-set values for 2018, 2019, 2020, 2025.  Values for 2021-2024 are linearly interpolated.